### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python trac.py"

--- a/README
+++ b/README
@@ -6,6 +6,7 @@ The same page has a link to a "beginner's manual" for Trac.  I've also made a
 blog post about this project, which is available at:
 http://nats-tech.blogspot.com/2013/07/the-land-of-trac.html.
 
+You can [![run it on Repl.it](https://repl.it/badge/github/natkuhn/Trac-in-Python)](https://repl.it/github/natkuhn/Trac-in-Python)
 The home page for this project is https://github.com/natkuhn/Trac-in-Python.  
 If you are looking at this file on that page, you can download the file 
 archive just by clicking the "Download ZIP" button in the right-hand sidebar.


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@NatKuhn/Trac-in-Python).